### PR TITLE
Disabled no-tags builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+if: tag IS present
+
 language: go
 
 go:


### PR DESCRIPTION
No sense to create non-tagged builds. Builded artifacts won't get
anywhere(only tagged commits trigger creation of
release on github).