### PR TITLE
Check transaction result when creating/updating/deleting some resources

### DIFF
--- a/tokend/account.go
+++ b/tokend/account.go
@@ -2,7 +2,6 @@ package tokend
 
 import (
 	"context"
-
 	"github.com/tokend/terraform-provider-tokend/tokend/helpers"
 
 	"github.com/tokend/terraform-provider-tokend/tokend/helpers/validation"
@@ -109,12 +108,14 @@ func resourceAccountCreate(d *schema.ResourceData, _m interface{}) error {
 			"op_codes": result.OpCodes,
 		})
 	}
+
 	var txResult xdr.TransactionResult
 	if err := xdr.SafeUnmarshalBase64(result.ResultXDR, &txResult); err != nil {
 		return errors.Wrap(err, "failed to decode result")
 	}
 
 	d.SetId(destination)
+
 	return nil
 }
 
@@ -137,11 +138,13 @@ func getSigner(rawSigner interface{}) (*xdrbuild.SignerData, error) {
 	}
 
 	publicKey := d["public_key"].(string)
+
 	rawWeight := d["weight"]
 	weight, err := cast.ToUint32E(rawWeight)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to cast weight to uint32")
 	}
+
 	rawIdentity := d["identity"]
 	identity, err := cast.ToUint32E(rawIdentity)
 	if err != nil {

--- a/tokend/account_rule.go
+++ b/tokend/account_rule.go
@@ -61,6 +61,7 @@ func resourceAccountRuleCreate(d *schema.ResourceData, _m interface{}) (err erro
 	}
 
 	actionRaw := d.Get("action").(string)
+
 	var action xdr.AccountRuleAction
 	if actionRaw == "*" {
 		action = xdr.AccountRuleActionAny
@@ -85,17 +86,22 @@ func resourceAccountRuleCreate(d *schema.ResourceData, _m interface{}) (err erro
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal tx")
 	}
+
 	result := m.Horizon.Submitter().Submit(context.TODO(), env)
 	if result.Err != nil {
 		return errors.Wrapf(result.Err, "failed to submit tx: %s %q", result.TXCode, result.OpCodes)
 	}
+
 	var txResult xdr.TransactionResult
 	if err := xdr.SafeUnmarshalBase64(result.ResultXDR, &txResult); err != nil {
 		return errors.Wrap(err, "failed to decode result")
 	}
+
 	txCodes := *(txResult.Result.Results)
 	ruleID := txCodes[0].Tr.ManageAccountRuleResult.Success.RuleId
+
 	d.SetId(fmt.Sprintf("%d", ruleID))
+
 	return nil
 }
 
@@ -132,10 +138,17 @@ func resourceAccountRuleUpdate(d *schema.ResourceData, _m interface{}) (err erro
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal tx")
 	}
+
 	result := m.Horizon.Submitter().Submit(context.TODO(), env)
 	if result.Err != nil {
 		return errors.Wrapf(result.Err, "failed to submit tx: %s %q", result.TXCode, result.OpCodes)
 	}
+
+	var txResult xdr.TransactionResult
+	if err := xdr.SafeUnmarshalBase64(result.ResultXDR, &txResult); err != nil {
+		return errors.Wrap(err, "failed to decode result")
+	}
+
 	return nil
 }
 

--- a/tokend/asset_pair.go
+++ b/tokend/asset_pair.go
@@ -58,11 +58,14 @@ func resourceAssetPairCreate(d *schema.ResourceData, _m interface{}) (err error)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal tx")
 	}
+
 	result := m.Horizon.Submitter().Submit(context.TODO(), env)
 	if result.Err != nil {
 		return errors.Wrapf(result.Err, "failed to submit tx: %s %q", result.TXCode, result.OpCodes)
 	}
+
 	d.SetId(buildId(base, quote))
+
 	return nil
 }
 
@@ -76,6 +79,7 @@ func resourceAssetPairRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAssetPairDelete(d *schema.ResourceData, _m interface{}) error {
 	m := _m.(Meta)
+
 	base := d.Get("base").(string)
 	quote := d.Get("quote").(string)
 
@@ -86,15 +90,19 @@ func resourceAssetPairDelete(d *schema.ResourceData, _m interface{}) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal tx")
 	}
+
 	result := m.Horizon.Submitter().Submit(context.TODO(), env)
 	if result.Err != nil {
 		return errors.Wrapf(result.Err, "failed to submit tx: %s %q", result.TXCode, result.OpCodes)
 	}
+
 	var txResult xdr.TransactionResult
 	if err := xdr.SafeUnmarshalBase64(result.ResultXDR, &txResult); err != nil {
 		return errors.Wrap(err, "failed to decode result")
 	}
+
 	d.SetId(buildId(base, quote))
+
 	return nil
 }
 

--- a/tokend/connector/connector.go
+++ b/tokend/connector/connector.go
@@ -1,9 +1,9 @@
 package connector
 
 import (
-	"gitlab.com/tokend/horizon-connector"
 	"github.com/tokend/terraform-provider-tokend/tokend/connector/keyvalues"
 	"github.com/tokend/terraform-provider-tokend/tokend/data"
+	"gitlab.com/tokend/horizon-connector"
 )
 
 type connector struct {

--- a/tokend/key_value.go
+++ b/tokend/key_value.go
@@ -3,13 +3,14 @@ package tokend
 import (
 	"context"
 	"fmt"
+	"gitlab.com/tokend/go/xdr"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/pkg/errors"
 	"github.com/spf13/cast"
-	"gitlab.com/tokend/go/xdrbuild"
 	"github.com/tokend/terraform-provider-tokend/tokend/helpers"
 	"github.com/tokend/terraform-provider-tokend/tokend/helpers/validation"
+	"gitlab.com/tokend/go/xdrbuild"
 )
 
 var keyValueSchema = map[string]*schema.Schema{
@@ -41,7 +42,9 @@ func resourceKeyValue() *schema.Resource {
 
 func resourceKeyValueCreate(d *schema.ResourceData, _m interface{}) (err error) {
 	m := _m.(Meta)
+
 	value := d.Get("value")
+
 	switch t := d.Get("value_type").(string); t {
 	case "string":
 	case "uint32":
@@ -57,6 +60,7 @@ func resourceKeyValueCreate(d *schema.ResourceData, _m interface{}) (err error) 
 	default:
 		return fmt.Errorf("value type is not supported: %s", t)
 	}
+
 	env, err := m.Builder.Transaction(m.Source).Op(&xdrbuild.PutKeyValue{
 		Key:   d.Get("key").(string),
 		Value: value,
@@ -64,10 +68,17 @@ func resourceKeyValueCreate(d *schema.ResourceData, _m interface{}) (err error) 
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal tx")
 	}
+
 	result := m.Horizon.Submitter().Submit(context.TODO(), env)
 	if result.Err != nil {
 		return errors.Wrapf(result.Err, "failed to submit tx: %s %q", result.TXCode, result.OpCodes)
 	}
+
+	var txResult xdr.TransactionResult
+	if err := xdr.SafeUnmarshalBase64(result.ResultXDR, &txResult); err != nil {
+		return errors.Wrap(err, "failed to decode result")
+	}
+
 	d.SetId(d.Get("key").(string))
 
 	return nil
@@ -75,7 +86,9 @@ func resourceKeyValueCreate(d *schema.ResourceData, _m interface{}) (err error) 
 
 func resourceKeyValueUpdate(d *schema.ResourceData, _m interface{}) (err error) {
 	m := _m.(Meta)
+
 	value := d.Get("value")
+
 	switch t := d.Get("value_type").(string); t {
 	case "string":
 	case "uint32":
@@ -91,6 +104,7 @@ func resourceKeyValueUpdate(d *schema.ResourceData, _m interface{}) (err error) 
 	default:
 		return fmt.Errorf("value type is not supported: %s", t)
 	}
+
 	env, err := m.Builder.Transaction(m.Source).Op(&xdrbuild.PutKeyValue{
 		Key:   d.Get("key").(string),
 		Value: value,
@@ -98,9 +112,15 @@ func resourceKeyValueUpdate(d *schema.ResourceData, _m interface{}) (err error) 
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal tx")
 	}
+
 	result := m.Horizon.Submitter().Submit(context.TODO(), env)
 	if result.Err != nil {
 		return errors.Wrapf(result.Err, "failed to submit tx: %s %q", result.TXCode, result.OpCodes)
+	}
+
+	var txResult xdr.TransactionResult
+	if err := xdr.SafeUnmarshalBase64(result.ResultXDR, &txResult); err != nil {
+		return errors.Wrap(err, "failed to decode result")
 	}
 
 	return nil
@@ -108,6 +128,7 @@ func resourceKeyValueUpdate(d *schema.ResourceData, _m interface{}) (err error) 
 
 func resourceKeyValueRead(d *schema.ResourceData, _m interface{}) error {
 	m := _m.(Meta)
+
 	key := d.Get("key").(string)
 
 	rawValue, err := m.Connector.KeyValues().Value(key)
@@ -125,15 +146,23 @@ func resourceKeyValueRead(d *schema.ResourceData, _m interface{}) error {
 
 func resourceKeyValueDelete(d *schema.ResourceData, _m interface{}) error {
 	m := _m.(Meta)
+
 	env, err := m.Builder.Transaction(m.Source).Op(&xdrbuild.RemoveKeyValue{
 		Key: d.Get("key").(string),
 	}).Sign(m.Signer).Marshal()
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal tx")
 	}
+
 	result := m.Horizon.Submitter().Submit(context.TODO(), env)
 	if result.Err != nil {
 		return errors.Wrap(result.Err, "failed to submit tx")
 	}
+
+	var txResult xdr.TransactionResult
+	if err := xdr.SafeUnmarshalBase64(result.ResultXDR, &txResult); err != nil {
+		return errors.Wrap(err, "failed to decode result")
+	}
+
 	return nil
 }

--- a/tokend/provider.go
+++ b/tokend/provider.go
@@ -52,19 +52,24 @@ func Provider() terraform.ResourceProvider {
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to parse endpoint")
 			}
+
 			signer, err := keypair.ParseSeed(d.Get("signer").(string))
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to parse signer")
 			}
+
 			source, err := keypair.ParseAddress(d.Get("account").(string))
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to parse source")
 			}
+
 			hrz := horizon.NewConnector(endpoint).WithSigner(signer)
+
 			builder, err := hrz.TXBuilder()
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to init builder")
 			}
+
 			return Meta{
 				Horizon:   hrz,
 				Connector: connector.NewConnector(hrz.Client()),

--- a/tokend/signer_role.go
+++ b/tokend/signer_role.go
@@ -53,6 +53,7 @@ func resourceSignerRoleCreate(d *schema.ResourceData, _m interface{}) (err error
 		if err != nil {
 			return errors.Wrap(err, "failed to cast raw rule")
 		}
+
 		rules = append(rules, rule)
 	}
 
@@ -63,17 +64,22 @@ func resourceSignerRoleCreate(d *schema.ResourceData, _m interface{}) (err error
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal tx")
 	}
+
 	result := m.Horizon.Submitter().Submit(context.TODO(), env)
 	if result.Err != nil {
 		return errors.Wrapf(result.Err, "failed to submit tx: %s %q", result.TXCode, result.OpCodes)
 	}
+
 	var txResult xdr.TransactionResult
 	if err := xdr.SafeUnmarshalBase64(result.ResultXDR, &txResult); err != nil {
 		return errors.Wrap(err, "failed to decode result")
 	}
+
 	txCodes := *(txResult.Result.Results)
 	roleID := txCodes[0].Tr.ManageSignerRoleResult.Success.RoleId
+
 	d.SetId(fmt.Sprintf("%d", roleID))
+
 	return nil
 }
 
@@ -109,10 +115,17 @@ func resourceSignerRoleUpdate(d *schema.ResourceData, _m interface{}) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal tx")
 	}
+
 	result := m.Horizon.Submitter().Submit(context.TODO(), env)
 	if result.Err != nil {
 		return errors.Wrapf(result.Err, "failed to submit tx: %s %q", result.TXCode, result.OpCodes)
 	}
+
+	var txResult xdr.TransactionResult
+	if err := xdr.SafeUnmarshalBase64(result.ResultXDR, &txResult); err != nil {
+		return errors.Wrap(err, "failed to decode result")
+	}
+
 	return nil
 }
 
@@ -134,9 +147,16 @@ func resourceSignerRoleDelete(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal tx")
 	}
+
 	result := m.Horizon.Submitter().Submit(context.TODO(), env)
 	if result.Err != nil {
 		return errors.Wrapf(result.Err, "failed to submit tx: %s %q", result.TXCode, result.OpCodes)
 	}
+
+	var txResult xdr.TransactionResult
+	if err := xdr.SafeUnmarshalBase64(result.ResultXDR, &txResult); err != nil {
+		return errors.Wrap(err, "failed to decode result")
+	}
+
 	return nil
 }


### PR DESCRIPTION
Allows making retries on errors, especially key-values.